### PR TITLE
Switch test & release to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: pull_request
+jobs:
+  test:
+    name: Test
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+      - name: Install dependencies
+        run: npm install
+      - name: Lint (JavaScript)
+        run: npm run lint:eslint
+      - name: Lint (Lit)
+        run: npm run lint:lit
+      - name: Unit Tests (SauceLabs)
+        run: npm run test:sauce
+        env:
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN }}
+          SAUCE_USERNAME: Desire2Learn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Release
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+      - name: Semantic Release
+        uses: BrightspaceUI/actions/semantic-release@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,6 @@ language: node_js
 node_js: node
 jobs:
   include:
-  - stage: tests
-    script:
-    - npm run lint
-    - |
-      if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
-        echo "Pull request with secure environment variables, running Sauce tests...";
-        npm run test:sauce || travis_terminate 1;
-      else
-        echo "Not a pull request and/or no secure environment variables, running headless tests...";
-        npm run test:headless || travis_terminate 1;
-      fi
-    env:
-      - SAUCE_USERNAME: Desire2Learn
-      # SAUCE_ACCESS_KEY
-      - secure: eppKo+hx7CXWT+9pqNRVkt0Wr4fXwS2MoQuKIYvtvRnKjO+SayjH0FbFn/eNqyyqosRjeO2CB11iRIv9YbPLiJfFeuOnmSKGVjwQ4wLob9pH/hAyl3/rBbjOJMER5Opx4tHktsJ7Uk6WycIUHhHaF6vuC3PpVE9aTFoShlGEbIl600cCX+FO8IoT/3vJDxM0X5HGbfZlaJvs1CCtJt1mPhhWmcuaVvLXYYWLAWPwyAmbgbw1fMcoID4AlMcxKuYpXNulkdh1GGqXEL0elW6dqIN5QJYbz2ae11PUeJ13yMAMKcJ4MEJWGlcd2wsXppVmiA2JVqw4n4XySLi9dhpZYEcxUubutA+kXdh2Vp7uTX1SmvRoYMwbrQGT5DWATTqJpM8EduSm2ansg9Exh+reRslz2pWzkBRSGg5G4LmRDAHzaoMM4nq7UlJWuiuhQJMxa+lCIN0U0j42sV9UQjPKZWNaLPvOlcKdJXA6vmh2tw5UH4yfCreZbOeGGgGXZJrGXNkgNY1sqSSXdazq2R3BY2JMtS0pmq+SJ4VOYdbI8y6TM4d4O4vU7sDwmT4e30NfNpMZ/U2NdvbaJq/DlUp9JGSGftL56SeaTU65nxLqbSyX1++l53Mtjds5QTbo7DWLbMwN/16UHRGOngWD5V8SRnN1SwfoqWPeM9JDg2xwaVY=
   - stage: Visual-difference-tests
     script:
     - |
@@ -29,15 +14,6 @@ jobs:
       - secure: mrlFbLMmD/OwgHjR+9yq8mn0vst3idLayYfomCEzmLGhY9cfMNCH+1R8SyAtBpCezaHUzL8VPwz+PLtChgpAnPsCRJWbVa46L5Wx4bsubMMyo15zID2Lazezi7o9OSa/athFt4JYw0y7HJ5hEvq/a4J1S4pXAJ5+ByTye8x9dFr8VACg2YhuE32ytMU/atuUCDKF/SyYpRSKClkiVqJ4FqUuSBD9acKkagEoftq8fuawbjAFAWR3K2HI6HVlJgbIXLRKDZp4qqoNzTJEnv2G7IgMaEY438+W1t4e/or3KlyORymhXOZXynuk1EwlBMWjpUQPhH6fUFBUnxY+JNlQS9aOuTX6ish3q5cy3c9tqWn9FITrctw3qHwmL9go4qQAxae0ZYfnfr6APd2fZ86+G+N3TkXxw9owL7hO4Dctm47c5Sz2hxg0WbC4eeh2+RbcMXsCRiYR879XF0mydTO9rilDVvCnDUQkYNcFoDy+L2aVn/hdeQRc0YV+z0ExeohAYtJESu6KhXqQReZmBGrYl8zzo0hJY13yPyRJEuL+AH5XaZ63k/s0O0zelIUxOiPgkgd8iq3AquBCIf2IhxSwgnH6T3PzZ1uK5PycuZ1mTQyFG2EBz+chocCgkw5RmbNP6VtuwxV8Pk2k+2r4WnAcRT67ra7DflydoTTh+nXL+zE=
       # VISUAL_DIFF_S3_SECRET
       - secure: UTqwii61qdsg8mwEtaEBeuhHq3qm1OWmkUi4Q06ghS1ZYLHzD1F9cxcI0ClNE1psEIETTXZ1O4USSDt69RYZrGeWvTgbjDiRDggkoJdnyYepFbnoXSFc+0juOy21oq4j5ey7X8rcUKALRsNuSwAIq6QNiaLoQ7p8T8wah9GipnZSyBCMtQKn9+x5jpxUh8vtbyhtunImBFNvltfgsHaS/INj3E6tXgwnN89RH02GIBVxirI1ENy0+IL6Tq36f0DZ5PmRPK/MOFiyGIhPv9XjzF1N7qlfEwBNlpK1MoRzuCUXQZpwPUw3m7zzAf8/fw3Y3aWB2rgtKG0kP2wsMIQbI1Buk5UUCry1G1g7XIPOSNUyvuCI+1cuxZ+9J4ByTPd7OKIagXxssGr7xQXPQDYTGPVW/8z0cvtVOys2lv8Z9+ZK1Ls97ZP1o4Bxo2DqM1CObrP5OkinnaF1pnRuUGOF+N37lzBF3uEcTcLh/s4B2wefZAmqLn3+KvUZEzjv6gmwN4i+cXSYjyACmqDE5XK9Vg8KJjSOTNgycGMx5JGEHWk0gjBAPaTt8HUgVLFzRM6m3iOS6WveRwB/THjYzFjk4j9KUcwYcXKC37jFjp2uuGpGNc4ThGXLofAR9vP+ZUNtoI3gJ4WROVU9ILZLiTFIOpRQ1Bsbli+yqd1XQXULmMQ=
-  - stage: deploy
-    script: skip
-    env:
-      # NPM_TOKEN 4428......a3d0
-      - secure: M8oQlHirkV1pbhCN4FZ2IxuPXnXZ6223NChqLXzZfaBpBYfHmIJivGAGytNs4Uhym8BcRgAna2lhcq3EPdDwNcQLDLq+cEO8QCjnTB3MKG102pvmLWxAI4f74Fe8ZuJ5QRTIEEMDurSI17hRCccuU1ho/B9CaWqpUPddadIAB4tVRh8dLtz7snEy3597fH6fvDBYNOkl7HIYZJtcLYrdI8jZS4bTtyAniQf+ldfDjUKVmEhsQ1I53n4YoNVZ7fPKDQlouH7Bflj9oXKDedUvZvpwkaI9+v4a81MDMTsXL8S22/aXVttMjgtxfyR7/p0xJ6yRS18x8lr8BVIawxPZlRth1V2PeUUmpEalp7DWMBxH/epBgM4oASSRW6xnlHNAWD8Va2AIHUQRZnyaoWnICMJXsskTKqAiOgjfqZ9s3znFB3wASk0onzMGMyaZgPMj94oZpz7Vpu0zMriVmG94n601WNPnjnVDgUW6kCBS08ln3VNIS+kQTKh619mKLv6H5vl4hUpi9toFruLLSQG3snjAiKFHs0km3Exfz0jSHLqcLGfCkcti9jNmKAamUoiJhGATT0obm0KXkGi4+z9R3E/SQChLA/RK7Vc13D/s38VJv4AzHFPJtTjsDVFWIeWgcwpLWwgHKDvL5GDk56Pnk3enR/9iqIpeprMT2NvirIE=
-    deploy:
-      provider: script
-      skip_cleanup: true
-      script: npx semantic-release
 env:
   global:
     # GITHUB_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js: node
+cache:
+  npm: false
 jobs:
   include:
   - stage: Visual-difference-tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # d2l-labs-status-icon
 
 [![NPM version](https://img.shields.io/npm/v/@brightspace-ui-labs/status-icon.svg)](https://www.npmjs.org/package/@brightspace-ui-labs/status-icon)
-[![Build status](https://travis-ci.com/BrightspaceUILabs/status-icon.svg?branch=master)](https://travis-ci.com/@brightspace-ui-labs/status-icon)
 
 > Note: this is a ["labs" component](https://github.com/BrightspaceUI/guide/wiki/Component-Tiers). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
 >
@@ -104,12 +103,41 @@ npm run test:diff:golden
 
 Golden snapshots in source control must be updated by Travis CI. To trigger an update, press the "Regenerate Goldens" button in the pull request `visual-difference` test run.
 
-## Versioning, Releasing & Deploying
+## Versioning & Releasing
 
-Releases use the [semantic-release](https://semantic-release.gitbook.io/) tooling and the [angular preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) for commit message syntax. All version changes should obey [semantic versioning](https://semver.org/) rules.
+> TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...
 
-Upon release, the version in `package.json` is updated, a tag and GitHub release is created and a new package will be deployed to NPM.
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
-Commits prefixed with `feat` will trigger a minor release, while `fix` or `perf` will trigger a patch release. A commit containing `BREAKING CHANGE:` in the _**message body**_ will cause a major release to occur.
+### Version Changes
 
-Other useful prefixes that will not trigger a release: `build`, `ci`, `docs`, `refactor`, `style` and `test`. More details in the [Angular Contribution Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type).
+All version changes should obey [semantic versioning](https://semver.org/) rules:
+1. **MAJOR** version when you make incompatible API changes,
+2. **MINOR** version when you add functionality in a backwards compatible manner, and
+3. **PATCH** version when you make backwards compatible bug fixes.
+
+The next version number will be determined from the commit messages since the previous release. Our semantic-release configuration uses the [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) when analyzing commits:
+* Commits which are prefixed with `fix:` or `perf:` will trigger a `patch` release. Example: `fix: validate input before using`
+* Commits which are prefixed with `feat:` will trigger a `minor` release. Example: `feat: add toggle() method`
+* To trigger a MAJOR release, include `BREAKING CHANGE:` with a space or two newlines in the footer of the commit message
+* Other suggested prefixes which will **NOT** trigger a release: `build:`, `ci:`, `docs:`, `style:`, `refactor:` and `test:`. Example: `docs: adding README for new component`
+
+To revert a change, add the `revert:` prefix to the original commit message. This will cause the reverted change to be omitted from the release notes. Example: `revert: fix: validate input before using`.
+
+### Releases
+
+When a release is triggered, it will:
+* Update the version in `package.json`
+* Tag the commit
+* Create a GitHub release (including release notes)
+* Deploy a new package to NPM
+
+### Releasing from Maintenance Branches
+
+Occasionally you'll want to backport a feature or bug fix to an older release. `semantic-release` refers to these as [maintenance branches](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches).
+
+Maintenance branch names should be of the form: `+([0-9])?(.{+([0-9]),x}).x`.
+
+Regular expressions are complicated, but this essentially means branch names should look like:
+* `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
+* `2.x` for feature releases on top of the `2` release (after version `3` exists)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@brightspace-ui/visual-diff": "^1",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^3",
-    "@semantic-release/git": "^9",
     "@webcomponents/webcomponentsjs": "^2",
     "babel-eslint": "^10",
     "deepmerge": "^3",
@@ -41,28 +40,10 @@
     "karma-sauce-launcher": "^2",
     "lit-analyzer": "^1",
     "mocha": "^8",
-    "puppeteer": "^5",
-    "semantic-release": "^17"
+    "puppeteer": "^5"
   },
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "lit-element": "^2"
-  },
-  "release": {
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/github",
-      "@semantic-release/npm",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]"
-        }
-      ]
-    ]
   }
 }


### PR DESCRIPTION
As discussed on Slack. @svanherk will switch the visuald-diff stuff over shortly, removing Travis CI entirely.