### PR TITLE
BREAKING CHANGE: bump dependencies to Lit 2 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ After cloning the repo, run `npm install` to install dependencies.
 
 To start a [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) that hosts the demo page and tests:
 
-
 ```shell
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ After cloning the repo, run `npm install` to install dependencies.
 
 To start a [@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) that hosts the demo page and tests:
 
+
 ```shell
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lit-analyzer": "^1"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^2",
+    "@brightspace-ui/core": "^1",
     "lit-element": "^3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lit-analyzer": "^1"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "lit-element": "^3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -37,7 +37,7 @@
     "lit-analyzer": "^1"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui/core": "^2",
+    "lit-element": "^3"
   }
 }


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: None needed

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [x] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.