### PR TITLE
fix: lit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3"
+    "lit": "^2"
   }
 }

--- a/status-icon.js
+++ b/status-icon.js
@@ -1,6 +1,6 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 function getIcon(state) {


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.